### PR TITLE
Servers config

### DIFF
--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -525,6 +525,9 @@ class db_login(object):
         label = self.win_gl.get_widget('combo_label')
         label.hide()
 
+        # Handle ServerConfig combobox if activated
+        combo_sc = self.win_gl.get_widget('combo_sc')
+        server_config = options.options['login.server_config']
         host = options.options['login.server']
         port = options.options['login.port']
         protocol = options.options['login.protocol']

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -480,6 +480,9 @@ class db_login(object):
         self.win_gl = glade.XML(common.terp_path("openerp.glade"),"win_login",gettext.textdomain())
         self.server_config_dict = {}
 
+    def get_servers(self):
+        self.server_config_dict = serversconfig.servers_config.options
+
     def refreshlist(self, widget, db_widget, entry_db, label, url, butconnect=False):
 
         def check_server_version(url):

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -503,6 +503,10 @@ class db_login(object):
                 port = selected_conf['port']
                 url = '%s%s:%s' % (protocol, host, port)
                 server_widget.set_text(url)
+
+                db = selected_conf['db']
+                database.set_text(db)
+
     def refreshlist(self, widget, db_widget, entry_db, label, url, butconnect=False):
 
         def check_server_version(url):

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -35,6 +35,7 @@ import rpc
 
 import service
 import options
+import serversconfig
 import common
 
 from window import win_preference, win_extension

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -496,6 +496,13 @@ class db_login(object):
             server_key = model[index][0]
             server_title = model[index][1]
 
+            try:
+                selected_conf = self.server_config_dict[server_key]
+                protocol = selected_conf['protocol']
+                host = selected_conf['host']
+                port = selected_conf['port']
+                url = '%s%s:%s' % (protocol, host, port)
+                server_widget.set_text(url)
     def refreshlist(self, widget, db_widget, entry_db, label, url, butconnect=False):
 
         def check_server_version(url):

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -545,6 +545,10 @@ class db_login(object):
             combo_sc.set_active(0)
             host = combo_sc.get_active()
             combo_sc.connect('changed', self.change_server_config)
+        else:
+            # todo hide combobox
+            pass
+
         host = options.options['login.server']
         port = options.options['login.port']
         protocol = options.options['login.protocol']

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -483,6 +483,15 @@ class db_login(object):
     def get_servers(self):
         self.server_config_dict = serversconfig.servers_config.options
 
+    def change_server_config(self, combobox):
+        model = combobox.get_model()
+        index = combobox.get_active()
+        server_widget = self.win_gl.get_widget('ent_server')
+        database_combo = self.win_gl.get_widget('combo_db')
+        database = self.win_gl.get_widget('ent_db')
+        login = self.win_gl.get_widget('ent_login')
+        passwd = self.win_gl.get_widget('ent_passwd')
+
     def refreshlist(self, widget, db_widget, entry_db, label, url, butconnect=False):
 
         def check_server_version(url):

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -492,6 +492,10 @@ class db_login(object):
         login = self.win_gl.get_widget('ent_login')
         passwd = self.win_gl.get_widget('ent_passwd')
 
+        if index:
+            server_key = model[index][0]
+            server_title = model[index][1]
+
     def refreshlist(self, widget, db_widget, entry_db, label, url, butconnect=False):
 
         def check_server_version(url):

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -543,6 +543,8 @@ class db_login(object):
             combo_sc.add_attribute(sc_cell, 'text', 1)
 
             combo_sc.set_active(0)
+            host = combo_sc.get_active()
+            combo_sc.connect('changed', self.change_server_config)
         host = options.options['login.server']
         port = options.options['login.port']
         protocol = options.options['login.protocol']

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -571,21 +571,26 @@ class db_login(object):
         combo_sc.hide()
         self.get_servers()
         if self.server_config_dict:
-            combo_sc.show()
-            sc_liststore = gtk.ListStore(str, str)
-            sc_liststore.append([0, "Select a saved config:"])
-            for key, server in self.server_config_dict.iteritems():
-                    a_title = "{} {} [{}]".format(server['organization'], server['type'], server['env'])
-                    sc_liststore.append([key, a_title])
+            try:
+                combo_sc.show()
+                sc_liststore = gtk.ListStore(str, str)
+                sc_liststore.append([0, "Select a saved config:"])
+                for key, server in self.server_config_dict.iteritems():
+                        a_title = "{} {} [{}]".format(server['organization'], server['type'], server['env'])
+                        sc_liststore.append([key, a_title])
 
-            combo_sc.set_model(sc_liststore)
-            sc_cell = gtk.CellRendererText()
-            combo_sc.pack_start(sc_cell, True)
-            combo_sc.add_attribute(sc_cell, 'text', 1)
+                combo_sc.set_model(sc_liststore)
+                sc_cell = gtk.CellRendererText()
+                combo_sc.pack_start(sc_cell, True)
+                combo_sc.add_attribute(sc_cell, 'text', 1)
 
-            combo_sc.set_active(0)
-            host = combo_sc.get_active()
-            combo_sc.connect('changed', self.change_server_config)
+                combo_sc.set_active(0)
+                host = combo_sc.get_active()
+                combo_sc.connect('changed', self.change_server_config)
+            except:
+                # Ensure combo is not showed on error
+                combo_sc.hide()
+                
 
         host = options.options['login.server']
         port = options.options['login.port']

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -536,6 +536,13 @@ class db_login(object):
             for key, server in self.server_config_dict.iteritems():
                     a_title = "{} {} [{}]".format(server['organization'], server['type'], server['env'])
                     sc_liststore.append([key, a_title])
+
+            combo_sc.set_model(sc_liststore)
+            sc_cell = gtk.CellRendererText()
+            combo_sc.pack_start(sc_cell, True)
+            combo_sc.add_attribute(sc_cell, 'text', 1)
+
+            combo_sc.set_active(0)
         host = options.options['login.server']
         port = options.options['login.port']
         protocol = options.options['login.protocol']

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -478,6 +478,7 @@ def _server_ask(server_widget, parent=None):
 class db_login(object):
     def __init__(self):
         self.win_gl = glade.XML(common.terp_path("openerp.glade"),"win_login",gettext.textdomain())
+        self.server_config_dict = {}
 
     def refreshlist(self, widget, db_widget, entry_db, label, url, butconnect=False):
 

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -566,12 +566,12 @@ class db_login(object):
         label = self.win_gl.get_widget('combo_label')
         label.hide()
 
-        # Handle ServerConfig combobox if activated
+        # Handle ServerConfig combobox if config exist
         combo_sc = self.win_gl.get_widget('combo_sc')
-        server_config = options.options['login.server_config']
-        if server_config:
-            self.get_servers()
-
+        combo_sc.hide()
+        self.get_servers()
+        if self.server_config_dict:
+            combo_sc.show()
             sc_liststore = gtk.ListStore(str, str)
             sc_liststore.append([0, "Select a saved config:"])
             for key, server in self.server_config_dict.iteritems():
@@ -586,8 +586,6 @@ class db_login(object):
             combo_sc.set_active(0)
             host = combo_sc.get_active()
             combo_sc.connect('changed', self.change_server_config)
-        else:
-            combo_sc.hide()
 
         host = options.options['login.server']
         port = options.options['login.port']

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -528,6 +528,14 @@ class db_login(object):
         # Handle ServerConfig combobox if activated
         combo_sc = self.win_gl.get_widget('combo_sc')
         server_config = options.options['login.server_config']
+        if server_config:
+            self.get_servers()
+
+            sc_liststore = gtk.ListStore(str, str)
+            sc_liststore.append([0, "Select a saved config:"])
+            for key, server in self.server_config_dict.iteritems():
+                    a_title = "{} {} [{}]".format(server['organization'], server['type'], server['env'])
+                    sc_liststore.append([key, a_title])
         host = options.options['login.server']
         port = options.options['login.port']
         protocol = options.options['login.protocol']

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -507,6 +507,11 @@ class db_login(object):
                 db = selected_conf['db']
                 database.set_text(db)
 
+                liststore = gtk.ListStore(str)
+                liststore.append([db])
+                database_combo.set_model(liststore)
+                cell = gtk.CellRendererText()
+                database_combo.set_active(0)
     def refreshlist(self, widget, db_widget, entry_db, label, url, butconnect=False):
 
         def check_server_version(url):

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -512,6 +512,18 @@ class db_login(object):
                 database_combo.set_model(liststore)
                 cell = gtk.CellRendererText()
                 database_combo.set_active(0)
+
+                user = selected_conf['user']
+                password = selected_conf['password']
+
+                login.set_text(user)
+                passwd.set_text(password)
+
+            except Exception as e:
+                print ("Error loading config for key '{}': '{}'".format(server_key, e))
+
+        return
+
     def refreshlist(self, widget, db_widget, entry_db, label, url, butconnect=False):
 
         def check_server_version(url):

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 ##############################################################################
 #
-#    OpenERP, Open Source Management Solution	
+#    OpenERP, Open Source Management Solution
 #    Copyright (C) 2004-2009 Tiny SPRL (<http://tiny.be>). All Rights Reserved
 #    $Id$
 #
@@ -172,7 +172,7 @@ class DatabaseDialog(gtk.Dialog):
                     win = gtk.Window(type=gtk.WINDOW_TOPLEVEL)
                     win.set_title(_('OpenERP Computing'))
                     win.set_position(gtk.WIN_POS_CENTER_ON_PARENT)
-                    win.set_modal(True) 
+                    win.set_modal(True)
                     vbox = gtk.VBox(False, 0)
                     hbox = gtk.HBox(False, 13)
                     hbox.set_border_width(10)
@@ -309,8 +309,8 @@ class MigrationDatabaseDialog(DatabaseDialog):
     def on_response_accept(self):
         databases = [ item[1] for item in self.model if bool(item[0]) ]
         if databases:
-            rpc.session.migrate_databases(self.serverEntry.get_text(), 
-                                          self.adminPwdEntry.get_text(), 
+            rpc.session.migrate_databases(self.serverEntry.get_text(),
+                                          self.adminPwdEntry.get_text(),
                                           databases)
             if len(databases) == 1:
                 self.message = _("Your database has been upgraded.")
@@ -587,8 +587,7 @@ class db_login(object):
             host = combo_sc.get_active()
             combo_sc.connect('changed', self.change_server_config)
         else:
-            # todo hide combobox
-            pass
+            combo_sc.hide()
 
         host = options.options['login.server']
         port = options.options['login.port']
@@ -1291,7 +1290,7 @@ class terp_main(service.Service):
         self.pages.append(win)
         box = gtk.HBox(False, 0)
 
-        # Draw the close button on the right 
+        # Draw the close button on the right
         closebtn = gtk.Button()
         image = gtk.Image()
         image.set_from_stock(gtk.STOCK_CLOSE, gtk.ICON_SIZE_MENU)
@@ -1635,4 +1634,3 @@ class terp_main(service.Service):
 
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
-

--- a/bin/openerp.glade
+++ b/bin/openerp.glade
@@ -209,6 +209,10 @@
             <property name="visible">True</property>
             <property name="layout_style">GTK_BUTTONBOX_END</property>
             <child>
+              <widget class="GtkComboBox" id="combo_sc">
+              </widget>
+            </child>
+            <child>
               <widget class="GtkButton" id="okbutton1">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>

--- a/bin/options.py
+++ b/bin/options.py
@@ -77,6 +77,7 @@ class configmanager(object):
             'login.server': 'localhost',
             'login.port': '8070',
             'login.protocol': 'socket://',
+            'login.server_config': False,
             'login.db': 'terp',
             'client.toolbar': 'both',
             'client.theme': 'none',

--- a/bin/options.py
+++ b/bin/options.py
@@ -77,7 +77,6 @@ class configmanager(object):
             'login.server': 'localhost',
             'login.port': '8070',
             'login.protocol': 'socket://',
-            'login.server_config': False,
             'login.db': 'terp',
             'client.toolbar': 'both',
             'client.theme': 'none',

--- a/bin/serversconfig.py
+++ b/bin/serversconfig.py
@@ -99,8 +99,6 @@ class ServersConfig(configmanager):
         if not os.path.exists(rcfile):
             log = logging.getLogger('common.options')
             additional_info = ""
-            if optconfigfile:
-                additional_info = " Be sure to specify an absolute path name if you are using the '-c' command line switch"
             log.warn('Config file %s does not exist !%s'% (rcfile, additional_info ))
         return os.path.abspath(rcfile)
 

--- a/bin/serversconfig.py
+++ b/bin/serversconfig.py
@@ -1,0 +1,110 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2004-2009 Tiny SPRL (<http://tiny.be>). All Rights Reserved
+#    $Id$
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import ConfigParser
+import os
+import logging
+from options import configmanager, get_home_dir
+
+
+class ServersConfig(configmanager):
+    """
+    Class to load servers definitions from a configfile:
+    - passed file name
+    - env OPENERPRCSERVERS
+    - ~/.openerprc.servers
+    """
+    def __init__(self, fname=None):
+        self.__prefix = None
+        self.options = {}
+        self.rcfile = self._get_rcfile(fname)
+        self.load()
+
+    def load(self, fname=None):
+        """
+        Load a config file as a dict
+        {
+            [key]: {
+                [opt1]: value,
+                [op2]: value2,
+            },
+            [key2]: {
+                [opt1]: value,
+            },
+            ...
+        """
+        try:
+            self.rcexist = False
+            if not os.path.isfile(self.rcfile):
+                self.save()
+                return False
+            self.rcexist = True
+
+            p = ConfigParser.RawConfigParser()
+            p.read([self.rcfile])
+
+            for section in p.sections():
+                if section not in self.options:
+                    self.options[section] = {}
+
+                for (name,value) in p.items(section):
+                    if value=='True' or value=='true':
+                        value = True
+                    if value=='False' or value=='false':
+                        value = False
+                    if value=='None' or value=='none':
+                        value = None
+                    self.options[section][name] = value
+
+        except Exception, e:
+            import logging
+            log = logging.getLogger('common.options')
+            log.warn('Unable to read server config file %s !'% (self.rcfile,))
+        return True
+
+    def save(self, fname = None):
+        """
+        Override save method to not alter server file
+        """
+        return True
+
+    def _get_rcfile(self, fname):
+        """
+        Override the way that the file is located
+
+        - If passed, use the fname
+        - Try to fetch env var OPENERPRCSERVERS
+        - Try to locate a .openerprc.servers file at user home
+        """
+        rcfile = fname or os.environ.get('OPENERPRCSERVERS') or os.path.join(get_home_dir(), '.openerprc.servers')
+        if not os.path.exists(rcfile):
+            log = logging.getLogger('common.options')
+            additional_info = ""
+            if optconfigfile:
+                additional_info = " Be sure to specify an absolute path name if you are using the '-c' command line switch"
+            log.warn('Config file %s does not exist !%s'% (rcfile, additional_info ))
+        return os.path.abspath(rcfile)
+
+
+servers_config = ServersConfig()
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:


### PR DESCRIPTION
It integrates a new combobox at Open Connection UI to handle the loading of preconfigured server connections to simplify the management of several ERP servers to connect

If servers definitions are not found, the combo is not displayed.

The connections must be placed at `~/.openerprc.servers` following this pattern:
```
[$key]
organization = $ORGANIZATION_NAME
env = PROD | PRE | DEV
type = comer | distri
protocol = http:// | https:// | socket://
host = $HOSTNAME
port = $PORT
db = $DB
user = $USERNAME
password = $PASSWORD
``` 
